### PR TITLE
Add Qlty Code Coverage Integration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -29,3 +30,9 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B install --file pom.xml
+
+      - name: Upload coverage to Qlty
+        if: matrix.java == 21
+        uses: qltysh/qlty-coverage-action@v1
+        with:
+          file: "**/target/site/jacoco/jacoco.xml"


### PR DESCRIPTION
## Summary

This PR integrates Qlty Code Coverage into the OpenPDF project's GitHub Actions CI workflow. The integration leverages the existing JaCoCo coverage configuration to upload coverage data to Qlty for tracking and visualization.

### Changes Made

- Added `id-token: write` permission to the workflow for OIDC authentication
- Added Qlty coverage upload step using the official `qltysh/qlty-coverage-action@v1`
- Configured to collect JaCoCo XML reports from all Maven modules using the pattern `**/target/site/jacoco/jacoco.xml`
- Coverage upload runs only on the Java 21 matrix job to avoid duplicate uploads

### Authentication Approach

This integration uses **OIDC authentication** (OpenID Connect), which is the recommended approach for GitHub Actions. This means:
- No secrets need to be added to the repository
- Authentication is handled securely through GitHub's OIDC provider
- The workflow automatically obtains temporary credentials for Qlty

### How It Works

1. The existing Maven build runs tests and generates JaCoCo coverage reports (already configured in `pom.xml`)
2. After a successful build, the Qlty action collects all `jacoco.xml` files from each module
3. Coverage data is uploaded to Qlty using OIDC authentication
4. Coverage reports are only uploaded from the Java 21 job to avoid duplicates across the matrix build

### Test Plan

- [ ] Verify that the CI build completes successfully
- [ ] Confirm that JaCoCo coverage reports are generated in each module's `target/site/jacoco/` directory
- [ ] Validate that coverage data is successfully uploaded to Qlty
- [ ] Check that coverage paths are correctly validated (no path fixing needed)
- [ ] Ensure no duplicate uploads occur from the matrix builds

Generated with [Claude Code](https://claude.com/claude-code)