### PR TITLE
Add Qlty Code Coverage integration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,10 +38,3 @@ jobs:
           oidc: true
           files: |
             **/target/site/jacoco/jacoco.xml
-          path-fixes: |
-            openpdf-core/target/site/jacoco/jacoco.xml add-prefix openpdf-core/src/main/java
-            openpdf-fonts-extra/target/site/jacoco/jacoco.xml add-prefix openpdf-fonts-extra/src/main/java
-            openpdf-html/target/site/jacoco/jacoco.xml add-prefix openpdf-html/src/main/java
-            openpdf-renderer/target/site/jacoco/jacoco.xml add-prefix openpdf-renderer/src/main/java
-            pdf-swing/target/site/jacoco/jacoco.xml add-prefix pdf-swing/src/main/java
-            pdf-toolbox/target/site/jacoco/jacoco.xml add-prefix pdf-toolbox/src/main/java

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,3 +38,10 @@ jobs:
           oidc: true
           files: |
             **/target/site/jacoco/jacoco.xml
+          path-fixes: |
+            openpdf-core/target/site/jacoco/jacoco.xml add-prefix openpdf-core/src/main/java
+            openpdf-fonts-extra/target/site/jacoco/jacoco.xml add-prefix openpdf-fonts-extra/src/main/java
+            openpdf-html/target/site/jacoco/jacoco.xml add-prefix openpdf-html/src/main/java
+            openpdf-renderer/target/site/jacoco/jacoco.xml add-prefix openpdf-renderer/src/main/java
+            pdf-swing/target/site/jacoco/jacoco.xml add-prefix pdf-swing/src/main/java
+            pdf-toolbox/target/site/jacoco/jacoco.xml add-prefix pdf-toolbox/src/main/java

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -29,3 +30,11 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B install --file pom.xml
+
+      - name: Publish coverage to Qlty
+        if: matrix.java == 21
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          oidc: true
+          files: |
+            **/target/site/jacoco/jacoco.xml

--- a/.qlty/coverage.yaml
+++ b/.qlty/coverage.yaml
@@ -1,0 +1,25 @@
+coverage:
+  path_fixes:
+    - file: "openpdf-core/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "openpdf-core/src/main/java"
+
+    - file: "openpdf-fonts-extra/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "openpdf-fonts-extra/src/main/java"
+
+    - file: "openpdf-html/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "openpdf-html/src/main/java"
+
+    - file: "openpdf-renderer/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "openpdf-renderer/src/main/java"
+
+    - file: "pdf-swing/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "pdf-swing/src/main/java"
+
+    - file: "pdf-toolbox/target/site/jacoco/jacoco.xml"
+      transforms:
+        - add_prefix: "pdf-toolbox/src/main/java"

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
-          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+          <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Summary

This PR integrates Qlty Code Coverage into the GitHub Actions CI pipeline to enable automated tracking and analysis of test coverage across all modules in the OpenPDF project.

### Changes Made

- Added `id-token: write` permission to enable OIDC authentication with Qlty
- Added coverage upload step using `qltysh/qlty-action/coverage@v2`
- Configured to collect JaCoCo XML reports from all modules using the pattern `**/target/site/jacoco/jacoco.xml`
- Limited coverage upload to the Java 21 matrix job to avoid duplicate uploads

### Authentication

This integration uses OIDC (OpenID Connect) authentication, which means:
- No secrets need to be manually configured
- GitHub provides temporary credentials automatically
- Secure, token-based authentication

### How It Works

1. The existing JaCoCo Maven plugin (already configured in `pom.xml`) generates coverage reports during the build
2. After tests pass, the Qlty action collects all `jacoco.xml` files from the multi-module project
3. Coverage data is uploaded to Qlty for analysis and tracking
4. Coverage is only uploaded from the Java 21 build to avoid duplicates from the matrix strategy

### Test Plan

- [ ] Verify CI build passes successfully
- [ ] Confirm coverage reports are generated by JaCoCo
- [ ] Validate Qlty action uploads coverage data successfully
- [ ] Check that coverage data appears in Qlty dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)