### PR TITLE
Add Qlty Code Coverage integration

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Upload coverage to Qlty
         uses: qltysh/qlty-action/coverage@v2
         if: success() && matrix.java == '21'
+        env:
+          JACOCO_SOURCE_PATH: openpdf-core/src/main/java openpdf-fonts-extra/src/main/java openpdf-html/src/main/java openpdf-kotlin/src/main/java openpdf-renderer/src/main/java pdf-swing/src/main/java pdf-toolbox/src/main/java
         with:
           oidc: true
           files: '**/target/site/jacoco/jacoco.xml'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -29,3 +30,10 @@ jobs:
 
       - name: Build with Maven
         run: mvn -B install --file pom.xml
+
+      - name: Upload coverage to Qlty
+        uses: qltysh/qlty-action/coverage@v2
+        if: success() && matrix.java == '21'
+        with:
+          oidc: true
+          files: '**/target/site/jacoco/jacoco.xml'

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
-          <argLine>-Dnet.bytebuddy.experimental=true</argLine>
+          <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
           </execution>
           <execution>
             <id>report</id>
-            <phase>prepare-package</phase>
+            <phase>test</phase>
             <goals>
               <goal>report</goal>
             </goals>


### PR DESCRIPTION
## Summary

This PR integrates Qlty Code Coverage into the OpenPDF project to enable automated code coverage tracking and reporting.

### Changes Made

1. **Updated JaCoCo Maven Plugin Configuration** (`pom.xml`)
   - Changed JaCoCo report generation phase from `prepare-package` to `test`
   - This ensures coverage reports are generated immediately after tests run
   - Coverage reports will be available at `target/site/jacoco/jacoco.xml` in each module

2. **Enhanced GitHub Actions Workflow** (`.github/workflows/maven.yml`)
   - Added `id-token: write` permission to enable OIDC authentication
   - Added Qlty coverage upload step using `qltysh/qlty-action/coverage@v2`
   - Coverage upload runs only on Java 21 builds to avoid duplicate submissions
   - Uses glob pattern `**/target/site/jacoco/jacoco.xml` to collect coverage from all modules

### Authentication

This integration uses **OpenID Connect (OIDC) authentication**, which is the recommended approach for GitHub Actions. This method:
- Requires no secret management or token configuration
- Provides secure, automatic authentication via GitHub's OIDC provider
- Eliminates the need to store and rotate coverage tokens

### Coverage Collection

The multi-module Maven project structure is fully supported:
- JaCoCo generates coverage reports for each module
- The glob pattern collects all module coverage files
- Qlty automatically merges coverage from all modules

### Test Plan

- [x] Verify GitHub Actions workflow syntax is correct
- [ ] Confirm CI build completes successfully
- [ ] Verify coverage reports are generated in each module's `target/site/jacoco/` directory
- [ ] Confirm coverage data is successfully uploaded to Qlty
- [ ] Check Qlty dashboard to ensure coverage appears correctly

### Next Steps

After merging this PR:
1. Monitor the CI build to ensure coverage uploads succeed
2. Visit the Qlty dashboard to view coverage reports
3. (Optional) Configure coverage threshold checks in Qlty settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)